### PR TITLE
Add debug_mode config check for logger usage in model cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to `laravel-model-cache` will be documented in this file.
 
+## [1.0.1] - 2025-05-04
+
+### Fixed
+
+- Add debug_mode config check for logger usage in model cache: This ensures logging of cache flush operations only
+  occurs when debug_mode is explicitly enabled in the configuration. It reduces unnecessary log entries in production
+  environments while retaining detailed logs for debugging purposes.
+
 ## [1.0.0] - 2025-05-01
 
 ### Added

--- a/src/CacheableBuilder.php
+++ b/src/CacheableBuilder.php
@@ -392,7 +392,7 @@ class CacheableBuilder extends Builder
             $cache = $this->getCacheDriver();
 
             // Log the operation if logger is available
-            if (function_exists('logger')) {
+            if (config('model-cache.debug_mode', false) && function_exists('logger')) {
                 logger()->info("Flushing specific query cache: " . $cacheKey);
                 logger()->debug("SQL: " . $this->toSql());
                 logger()->debug("Bindings: " . json_encode($this->getBindings()));
@@ -404,7 +404,7 @@ class CacheableBuilder extends Builder
             $result = $cache->forget($cacheKey);
             if ($result) {
                 $success = true;
-                if (function_exists('logger')) {
+                if (config('model-cache.debug_mode', false) && function_exists('logger')) {
                     logger()->debug("Successfully removed specific cache key: " . $cacheKey);
                 }
             }
@@ -422,12 +422,12 @@ class CacheableBuilder extends Builder
                     $cache->tags($queryTags)->flush();
 
                     $success = true;
-                    if (function_exists('logger')) {
+                    if (config('model-cache.debug_mode', false) && function_exists('logger')) {
                         logger()->debug("Successfully flushed cache using tags for model: " . get_class($this->model));
                     }
                 } catch (\Exception $e) {
                     // If this fails, we already tried the direct key removal above
-                    if (function_exists('logger')) {
+                    if (config('model-cache.debug_mode', false) && function_exists('logger')) {
                         logger()->debug("Could not flush by query tags: " . $e->getMessage());
                     }
                 }
@@ -438,7 +438,7 @@ class CacheableBuilder extends Builder
                 if (method_exists($this->model, 'flushModelCache')) {
                     $this->model->flushModelCache();
                     $success = true;
-                    if (function_exists('logger')) {
+                    if (config('model-cache.debug_mode', false) && function_exists('logger')) {
                         logger()->info("Flushed entire model cache for: " . get_class($this->model));
                     }
                 }
@@ -446,7 +446,7 @@ class CacheableBuilder extends Builder
 
             return $success || $result;
         } catch (\Exception $e) {
-            if (function_exists('logger')) {
+            if (config('model-cache.debug_mode', false) && function_exists('logger')) {
                 logger()->error("Error flushing query cache: " . $e->getMessage());
             }
             return false;
@@ -814,7 +814,7 @@ class CacheableBuilder extends Builder
 
         // Flush the cache for this model
         if ($result) {
-            if (function_exists('logger')) {
+            if (config('model-cache.debug_mode', false) && function_exists('logger')) {
                 logger()->info("Flushing cache after mass update for model: " . get_class($this->model));
             }
 
@@ -842,7 +842,7 @@ class CacheableBuilder extends Builder
 
         // Flush the cache for this model if any records were deleted
         if ($result) {
-            if (function_exists('logger')) {
+            if (config('model-cache.debug_mode', false) && function_exists('logger')) {
                 logger()->info("Flushing cache after mass delete for model: " . get_class($this->model));
             }
 
@@ -873,7 +873,7 @@ class CacheableBuilder extends Builder
 
         // Flush the cache for this model
         if ($result) {
-            if (function_exists('logger')) {
+            if (config('model-cache.debug_mode', false) && function_exists('logger')) {
                 logger()->info("Flushing cache after increment operation for model: " . get_class($this->model));
             }
 
@@ -904,7 +904,7 @@ class CacheableBuilder extends Builder
 
         // Flush the cache for this model
         if ($result) {
-            if (function_exists('logger')) {
+            if (config('model-cache.debug_mode', false) && function_exists('logger')) {
                 logger()->info("Flushing cache after decrement operation for model: " . get_class($this->model));
             }
 
@@ -933,7 +933,7 @@ class CacheableBuilder extends Builder
 
         // Flush the cache for this model if insert was successful
         if ($result) {
-            if (function_exists('logger')) {
+            if (config('model-cache.debug_mode', false) && function_exists('logger')) {
                 logger()->info("Flushing cache after insert operation for model: " . get_class($this->model));
             }
 
@@ -962,7 +962,7 @@ class CacheableBuilder extends Builder
 
         // Flush the cache for this model if any records were inserted
         if ($result > 0) {
-            if (function_exists('logger')) {
+            if (config('model-cache.debug_mode', false) && function_exists('logger')) {
                 logger()->info("Flushing cache after insertOrIgnore operation for model: " . get_class($this->model));
             }
 
@@ -992,7 +992,7 @@ class CacheableBuilder extends Builder
 
         // Flush the cache for this model
         if ($result) {
-            if (function_exists('logger')) {
+            if (config('model-cache.debug_mode', false) && function_exists('logger')) {
                 logger()->info("Flushing cache after insertGetId operation for model: " . get_class($this->model));
             }
 
@@ -1022,7 +1022,7 @@ class CacheableBuilder extends Builder
 
         // Flush the cache for this model if operation was successful
         if ($result) {
-            if (function_exists('logger')) {
+            if (config('model-cache.debug_mode', false) && function_exists('logger')) {
                 logger()->info("Flushing cache after updateOrInsert operation for model: " . get_class($this->model));
             }
 
@@ -1058,7 +1058,7 @@ class CacheableBuilder extends Builder
 
         // Flush the cache for this model if any records were affected
         if ($result > 0) {
-            if (function_exists('logger')) {
+            if (config('model-cache.debug_mode', false) && function_exists('logger')) {
                 logger()->info("Flushing cache after upsert operation for model: " . get_class($this->model));
             }
 
@@ -1085,7 +1085,7 @@ class CacheableBuilder extends Builder
         parent::truncate();
 
         // Always flush the cache after truncate
-        if (function_exists('logger')) {
+        if (config('model-cache.debug_mode', false) && function_exists('logger')) {
             logger()->info("Flushing cache after truncate operation for model: " . get_class($this->model));
         }
 
@@ -1116,7 +1116,7 @@ class CacheableBuilder extends Builder
 
         // Flush the cache for this model
         if ($result) {
-            if (function_exists('logger')) {
+            if (config('model-cache.debug_mode', false) && function_exists('logger')) {
                 logger()->info("Flushing cache after force delete for model: " . get_class($this->model));
             }
 
@@ -1150,7 +1150,7 @@ class CacheableBuilder extends Builder
 
         // Flush the cache for this model
         if ($result) {
-            if (function_exists('logger')) {
+            if (config('model-cache.debug_mode', false) && function_exists('logger')) {
                 logger()->info("Flushing cache after restore for model: " . get_class($this->model));
             }
 

--- a/src/HasCachedQueries.php
+++ b/src/HasCachedQueries.php
@@ -41,7 +41,7 @@ trait HasCachedQueries
         // Flush the cache when a model is created
         static::created(function ($model) {
             static::flushModelCache();
-            if (function_exists('logger')) {
+            if (config('model-cache.debug_mode', false) && function_exists('logger')) {
                 logger()->info("Cache flushed after creation for model: " . get_class($model));
             }
         });
@@ -49,7 +49,7 @@ trait HasCachedQueries
         // Flush the cache when a model is updated
         static::updated(function ($model) {
             static::flushModelCache();
-            if (function_exists('logger')) {
+            if (config('model-cache.debug_mode', false) && function_exists('logger')) {
                 logger()->info("Cache flushed after update for model: " . get_class($model));
             }
         });
@@ -57,7 +57,7 @@ trait HasCachedQueries
         // Flush the cache when a model is saved
         static::saved(function ($model) {
             static::flushModelCache();
-            if (function_exists('logger')) {
+            if (config('model-cache.debug_mode', false) && function_exists('logger')) {
                 logger()->info("Cache flushed after update for model: " . get_class($model));
             }
         });
@@ -65,7 +65,7 @@ trait HasCachedQueries
         // Flush the cache when a model is deleted
         static::deleted(function ($model) {
             static::flushModelCache();
-            if (function_exists('logger')) {
+            if (config('model-cache.debug_mode', false) && function_exists('logger')) {
                 logger()->info("Cache flushed after deletion for model: " . get_class($model));
             }
         });
@@ -73,7 +73,7 @@ trait HasCachedQueries
         // Flush the cache when a model is restored
         static::registerModelEvent('restored', function ($model) {
             static::flushModelCache();
-            if (function_exists('logger')) {
+            if (config('model-cache.debug_mode', false) && function_exists('logger')) {
                 logger()->info("Cache flushed after restoration for model: " . get_class($model));
             }
         });
@@ -108,12 +108,12 @@ trait HasCachedQueries
             if (method_exists($cache, 'tags') && $cache->supportsTags()) {
                 try {
                     $result = $cache->tags($tags)->flush();
-                    if (function_exists('logger')) {
+                    if (config('model-cache.debug_mode', false) && function_exists('logger')) {
                         logger()->info("Cache flushed statically for model: " . $modelClass);
                     }
                     return $result;
                 } catch (\Exception $e) {
-                    if (function_exists('logger')) {
+                    if (config('model-cache.debug_mode', false) && function_exists('logger')) {
                         logger()->error("Error flushing cache with tags for model {$modelClass}: " . $e->getMessage());
                     }
                     // Continue to fallback method if tags fail
@@ -122,13 +122,13 @@ trait HasCachedQueries
 
             // Fallback to flush the entire cache
             $result = $cache->flush();
-            if (function_exists('logger')) {
+            if (config('model-cache.debug_mode', false) && function_exists('logger')) {
                 logger()->info("Entire cache flushed for model: " . $modelClass);
             }
             return $result;
 
         } catch (\Exception $e) {
-            if (function_exists('logger')) {
+            if (config('model-cache.debug_mode', false) && function_exists('logger')) {
                 logger()->error("Error in flushCacheStatic for model " . static::class . ": " . $e->getMessage());
             }
             return false;
@@ -169,7 +169,7 @@ trait HasCachedQueries
             ];
 
             // Debug info
-            if (function_exists('logger')) {
+            if (config('model-cache.debug_mode', false) && function_exists('logger')) {
                 logger()->debug("Attempting to flush cache for model: " . static::class . " (Table: " . $this->getTable() . ")");
             }
 
@@ -177,12 +177,12 @@ trait HasCachedQueries
             if ($this->supportsTags($cache)) {
                 try {
                     $result = $cache->tags($tags)->flush();
-                    if (function_exists('logger')) {
+                    if (config('model-cache.debug_mode', false) && function_exists('logger')) {
                         logger()->info("Cache cleared with tags for model: " . static::class);
                     }
                     return $result;
                 } catch (\Exception $e) {
-                    if (function_exists('logger')) {
+                    if (config('model-cache.debug_mode', false) && function_exists('logger')) {
                         logger()->warning("Error using tags to flush cache: " . $e->getMessage() . ". Falling back to full cache clear.");
                     }
                     // Continue to fallback method
@@ -192,13 +192,13 @@ trait HasCachedQueries
             // For simplicity and to ensure it actually clears the cache,
             // flush the entire cache when tags aren't supported
             $result = $cache->flush();
-            if (function_exists('logger')) {
+            if (config('model-cache.debug_mode', false) && function_exists('logger')) {
                 logger()->info("Entire cache flushed for model: " . static::class);
             }
             return $result;
 
         } catch (\Exception $e) {
-            if (function_exists('logger')) {
+            if (config('model-cache.debug_mode', false) && function_exists('logger')) {
                 logger()->error("Error in flushCache: " . $e->getMessage());
             }
             return false;
@@ -224,7 +224,7 @@ trait HasCachedQueries
         } catch (\Exception $e) {
             // If there's an issue with the configured cache driver,
             // fall back to the default driver
-            if (function_exists('logger')) {
+            if (config('model-cache.debug_mode', false) && function_exists('logger')) {
                 logger()->error('Error getting cache driver: ' . $e->getMessage());
             }
             return \Illuminate\Support\Facades\Cache::store(config('cache.default'));

--- a/src/ModelRelationships.php
+++ b/src/ModelRelationships.php
@@ -52,7 +52,7 @@ trait ModelRelationships
         if (method_exists($model, 'flushModelCache')) {
             $model->flushModelCache();
 
-            if (function_exists('logger')) {
+            if (config('model-cache.debug_mode', false) && function_exists('logger')) {
                 logger()->info("Cache flushed after relationship operation for model: " . get_class($model));
             }
         }
@@ -78,7 +78,7 @@ trait ModelRelationships
         if (method_exists($this, 'flushModelCache')) {
             $this->flushModelCache();
 
-            if (function_exists('logger')) {
+            if (config('model-cache.debug_mode', false) && function_exists('logger')) {
                 logger()->info("Cache flushed after sync operation for model: " . get_class($this));
             }
         }
@@ -107,7 +107,7 @@ trait ModelRelationships
         if (method_exists($this, 'flushModelCache')) {
             $this->flushModelCache();
 
-            if (function_exists('logger')) {
+            if (config('model-cache.debug_mode', false) && function_exists('logger')) {
                 logger()->info("Cache flushed after attach operation for model: " . get_class($this));
             }
         }
@@ -133,7 +133,7 @@ trait ModelRelationships
         if (method_exists($this, 'flushModelCache')) {
             $this->flushModelCache();
 
-            if (function_exists('logger')) {
+            if (config('model-cache.debug_mode', false) && function_exists('logger')) {
                 logger()->info("Cache flushed after detach operation for model: " . get_class($this));
             }
         }


### PR DESCRIPTION
This ensures logging of cache flush operations only occurs when debug_mode is explicitly enabled in the configuration. It reduces unnecessary log entries in production environments while retaining detailed logs for debugging purposes.