### PR TITLE
Add support for custom cache prefix and relationship caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to `laravel-model-cache` will be documented in this file.
 
+## [1.1.0] - 2025-05-13
+
+### Added
+- Added support for custom cache prefix per model via `$cachePrefix` property
+- Added `ModelRelationships` trait to support cache invalidation for Eloquent relationship operations
+- Support for flushing cache on belongsToMany relationship events (saved, attached, detached, synced, updated)
+- New helper methods for relationship operations with automatic cache flushing: `syncRelationshipAndFlushCache()`, `attachRelationshipAndFlushCache()`, `detachRelationshipAndFlushCache()`
+- Debug logging for relationship-triggered cache flush operations when debug_mode is enabled
+
+### Fixed
+- Fixed issue with custom cache minutes (`$cacheMinutes`) definition at the model level
+- Improved cache invalidation when working with Eloquent relationships
+- Better handling of model relationship events to ensure cache consistency
+
+
+
 ## [1.0.1] - 2025-05-04
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -157,6 +157,9 @@ class Post extends Model
     
     // Optional: Override the default cache duration for this model
     protected $cacheMinutes = 120; // 2 hours
+    
+    // Optional: Override the global prefix from config('model-cache.cache_key_prefix') for this model
+    protected $cachePrefix = 'posts_';
 }
 ```
 

--- a/src/CacheableBuilder.php
+++ b/src/CacheableBuilder.php
@@ -16,6 +16,24 @@ class CacheableBuilder extends Builder
      */
     protected $cacheMinutes;
 
+
+    /**
+     * Define a custom cache prefix for this model.
+     * If not set, the global prefix from config('model-cache.cache_key_prefix') will be used.
+     *
+     * @var string
+     */
+    protected $cachePrefix;
+
+
+    public function __construct($builder, $cacheMinutes = null, $cachePrefix = null)
+    {
+        $this->cacheMinutes = $cacheMinutes;
+        $this->cachePrefix = $cachePrefix;
+        parent::__construct($builder);
+    }
+
+
     /**
      * Create a new model instance and store it in the database.
      *
@@ -340,7 +358,8 @@ class CacheableBuilder extends Builder
     public function getCacheKey($columns = ['*'])
     {
         // This is the prefix defined in our package config
-        $configPrefix = config('model-cache.cache_key_prefix', 'model_cache_');
+        $configPrefix = $this->cachePrefix ?? config('model-cache.cache_key_prefix', 'model_cache_');
+
 
         // Create unique components for our key
         $keyComponents = [
@@ -356,10 +375,10 @@ class CacheableBuilder extends Builder
         if (count($this->eagerLoad) > 0) {
             $keyComponents[] = 'with:' . serialize(array_keys($this->eagerLoad));
         }
-    
+
         // Create a hash from all components
         $uniqueKey = md5(implode('|', $keyComponents));
-    
+
         // Add debug logging if enabled
         if (config('model-cache.debug_mode', false) && function_exists('logger')) {
             logger()->debug("Generated cache key: {$uniqueKey} for query: {$this->toSql()} with bindings: " . json_encode($this->getBindings()) . " and relations: " . json_encode(array_keys($this->eagerLoad)));

--- a/src/HasCachedQueries.php
+++ b/src/HasCachedQueries.php
@@ -5,8 +5,13 @@ namespace YMigVal\LaravelModelCache;
 use Illuminate\Contracts\Cache\Repository;
 use Illuminate\Database\Query\Builder;
 
+/**
+ * @property ?int $cacheMinutes
+ * @property ?string $cachePrefix
+ */
 trait HasCachedQueries
 {
+
     /**
      * Create a new Eloquent query builder for the model.
      *
@@ -15,7 +20,11 @@ trait HasCachedQueries
      */
     public function newEloquentBuilder($query)
     {
-        return new CacheableBuilder($query);
+        return new CacheableBuilder(
+            $query,
+            $this->cacheMinutes,
+            $this->cachePrefix,
+        );
     }
 
     /**


### PR DESCRIPTION
Introduced `$cachePrefix` property for per-model cache prefixes and enhanced relationship operation caching with automatic cache invalidation. Added new helper methods and debug logging for improved cache management. Fixed issues with `cacheMinutes` and ensured consistency in relationship event handling.