### PR TITLE
Fix BelongsToMany cache handling with custom implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to `laravel-model-cache` will be documented in this file.
 
+## [1.1.3] - 2025-05-30
+
+### Fixed
+- Updated `CachingBelongsToMany` class to properly extend Laravel's BelongsToMany class and maintain the relationship contract. This resolves the "must return a relationship instance" error when accessing relationship properties after operations like attach() and detach().
+
+## [1.1.2] - 2025-05-25
+
+### Fixed
+- Fixed implementation of the `ModelRelationships` trait to properly handle BelongsToMany operations. Replaced the event-based approach (which was relying on non-existent Laravel events) with a custom BelongsToMany relationship class that flushes the cache after attach, detach, sync, syncWithoutDetaching, and updateExistingPivot operations.
+
 ## [1.1.1] - 2025-05-19
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -404,8 +404,9 @@ $post->detachRelationshipAndFlushCache('tags', [1, 3]);
 
 ### Automatic Cache Invalidation
 
-The trait also registers event listeners that automatically flush the cache when Laravel's relationship methods are
-used:
+The trait also automatically flushes the cache when Laravel's standard relationship methods are
+used by providing a custom BelongsToMany relationship implementation:
+
 
 ```php
 // These operations will automatically flush the cache
@@ -413,6 +414,7 @@ $post->tags()->attach(1);
 $post->tags()->detach([2, 3]);
 $post->tags()->sync([1, 4, 5]);
 $post->tags()->updateExistingPivot(1, ['featured' => true]);
+$post->tags()->syncWithoutDetaching([1, 5]);
 ```
 
 This ensures that your cached queries always reflect the current state of your model relationships.

--- a/src/CachingBelongsToMany.php
+++ b/src/CachingBelongsToMany.php
@@ -1,0 +1,155 @@
+<?php
+
+namespace YMigVal\LaravelModelCache;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+
+class CachingBelongsToMany extends BelongsToMany
+{
+    /**
+     * The parent model that should have its cache flushed.
+     *
+     * @var Model
+     */
+    protected $cacheableParent;
+
+    /**
+     * Create a new belongs to many relationship instance.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @param  \Illuminate\Database\Eloquent\Model  $parent
+     * @param  string  $table
+     * @param  string  $foreignPivotKey
+     * @param  string  $relatedPivotKey
+     * @param  string  $parentKey
+     * @param  string  $relatedKey
+     * @param  string  $relationName
+     * @param  Model  $cacheableParent
+     * @return void
+     */
+    public function __construct($query, $parent, $table, $foreignPivotKey, 
+                               $relatedPivotKey, $parentKey, $relatedKey, 
+                               $relationName = null, $cacheableParent = null)
+    {
+        parent::__construct(
+            $query, $parent, $table, $foreignPivotKey, 
+            $relatedPivotKey, $parentKey, $relatedKey, $relationName
+        );
+        
+        // Store the parent model that has the cache trait
+        $this->cacheableParent = $cacheableParent ?: $parent;
+    }
+
+    /**
+     * Attach a model to the parent.
+     *
+     * @param  mixed  $id
+     * @param  array  $attributes
+     * @param  bool  $touch
+     * @return void
+     */
+    public function attach($id, array $attributes = [], $touch = true)
+    {
+        // Call parent method to perform the actual attach
+        parent::attach($id, $attributes, $touch);
+        
+        // Flush cache after operation
+        $this->flushCache('attach');
+    }
+
+    /**
+     * Detach models from the relationship.
+     *
+     * @param  mixed  $ids
+     * @param  bool  $touch
+     * @return int
+     */
+    public function detach($ids = null, $touch = true)
+    {
+        // Call parent method to perform the actual detach
+        $result = parent::detach($ids, $touch);
+        
+        // Flush cache after operation
+        $this->flushCache('detach');
+        
+        return $result;
+    }
+
+    /**
+     * Sync the intermediate tables with a list of IDs or collection of models.
+     *
+     * @param  \Illuminate\Support\Collection|\Illuminate\Database\Eloquent\Model|array  $ids
+     * @param  bool  $detaching
+     * @return array
+     */
+    public function sync($ids, $detaching = true)
+    {
+        // Call parent method to perform the actual sync
+        $result = parent::sync($ids, $detaching);
+        
+        // Flush cache after operation
+        $this->flushCache('sync');
+        
+        return $result;
+    }
+
+    /**
+     * Update an existing pivot record on the table.
+     *
+     * @param  mixed  $id
+     * @param  array  $attributes
+     * @param  bool  $touch
+     * @return int
+     */
+    public function updateExistingPivot($id, array $attributes, $touch = true)
+    {
+        // Call parent method to perform the actual update
+        $result = parent::updateExistingPivot($id, $attributes, $touch);
+        
+        // Flush cache after operation
+        $this->flushCache('updateExistingPivot');
+        
+        return $result;
+    }
+
+    /**
+     * Sync the intermediate tables with a list of IDs without detaching.
+     *
+     * @param  \Illuminate\Support\Collection|\Illuminate\Database\Eloquent\Model|array  $ids
+     * @return array
+     */
+    public function syncWithoutDetaching($ids)
+    {
+        // Call parent method to perform the actual sync
+        $result = parent::syncWithoutDetaching($ids);
+        
+        // Flush cache after operation
+        $this->flushCache('syncWithoutDetaching');
+        
+        return $result;
+    }
+
+    /**
+     * Flush the model cache after a relationship operation.
+     *
+     * @param  string  $operation
+     * @return void
+     */
+    protected function flushCache($operation)
+    {
+        if (method_exists($this->cacheableParent, 'flushModelCache')) {
+            $this->cacheableParent->flushModelCache();
+        } else {
+            if (method_exists($this->cacheableParent, 'flushCache')) {
+                $this->cacheableParent->flushCache();
+            } else {
+                throw new \Exception('The parent model must have a flushCache() or flushModelCache() method defined. Make sure your model uses the HasCachedQueries trait. The ModelRelationships trait should be used in conjunction with the HasCachedQueries trait. See the documentation for more information.');
+            }
+        }
+
+        if (config('model-cache.debug_mode', false) && function_exists('logger')) {
+            logger()->info("Cache flushed after {$operation} operation for model: " . get_class($this->cacheableParent));
+        }
+    }
+}


### PR DESCRIPTION
Introduced `CachingBelongsToMany` to ensure proper cache invalidation after operations like attach, detach, sync, and updateExistingPivot. Updated the `ModelRelationships` trait to utilize this custom implementation, resolving bugs caused by reliance on non-existent Laravel events. Updated documentation to reflect these changes.