### PR TITLE
fix: Compatibility with Laravel PR 58639 (ver. 12.51.0)

### DIFF
--- a/src/CacheableBuilder.php
+++ b/src/CacheableBuilder.php
@@ -2,6 +2,7 @@
 
 namespace YMigVal\LaravelModelCache;
 
+use Closure;
 use Illuminate\Contracts\Cache\Repository;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
@@ -89,10 +90,10 @@ class CacheableBuilder extends Builder
      * Get the first record matching the attributes or create it.
      *
      * @param array $attributes
-     * @param array $values
+     * @param Closure|array $values
      * @return \Illuminate\Database\Eloquent\Model|static
      */
-    public function firstOrCreate(array $attributes = [], array $values = [])
+    public function firstOrCreate(array $attributes = [], Closure|array $values = [])
     {
         $model = parent::firstOrCreate($attributes, $values);
 


### PR DESCRIPTION
This pull request introduces a minor update to the `CacheableBuilder` class, expanding its flexibility by allowing the `firstOrCreate` method to accept either a `Closure` or an array for the `$values` parameter.

* Method signature update:
  * [`src/CacheableBuilder.php`](diffhunk://#diff-86136cb0afe5f8271fd46b20669cca9180a042f53ccb51cb941109486ac84f66L92-R96): The `firstOrCreate` method now accepts a `Closure` or an array for the `$values` parameter, aligning its behavior with the latest Laravel conventions.

* Dependency import:
  * [`src/CacheableBuilder.php`](diffhunk://#diff-86136cb0afe5f8271fd46b20669cca9180a042f53ccb51cb941109486ac84f66R5): Added the `Closure` import to support the updated method signature.
  
This change was triggered by merging https://github.com/laravel/framework/pull/58639 and released under version 12.51.0.